### PR TITLE
Handle test names with varying numbers

### DIFF
--- a/deps/ChartWidgets.py
+++ b/deps/ChartWidgets.py
@@ -34,6 +34,7 @@ from pyqtgraph.icons import getGraphIcon
 from pyqtgraph.Point import Point
 from pyqtgraph.graphicsItems.ScatterPlotItem import drawSymbol
 import deps.SharedSrc as ss
+from deps.SharedSrc import strip_test_number
 
 pg.setConfigOptions(foreground='k', background='w', antialias=False)
 
@@ -628,8 +629,9 @@ class TrendChart(GraphicViewWithMenu):
         if y_min == y_max:
             y_min -= 1
             y_max += 1
-        # add title
-        self.plotlayout.addLabel(f"{test_num} {test_name}", row=0, col=0, 
+        # add title, remove trailing number in test name if any
+        base_name = strip_test_number(test_name)
+        self.plotlayout.addLabel(f"{test_num} {base_name}", row=0, col=0,
                                  rowspan=1, colspan=len(testInfo),
                                  size="20pt")
         # create same number of viewboxes as file counts
@@ -805,8 +807,9 @@ class HistoChart(TrendChart):
         if y_min == y_max:
             y_min -= 1
             y_max += 1
-        # add title
-        self.plotlayout.addLabel(f"{test_num} {test_name}", row=0, col=0, 
+        # add title, remove trailing number in test name if any
+        base_name = strip_test_number(test_name)
+        self.plotlayout.addLabel(f"{test_num} {base_name}", row=0, col=0,
                                  rowspan=1, colspan=len(testInfo),
                                  size="20pt")
         # create same number of viewboxes as file counts

--- a/deps/DataInterface.py
+++ b/deps/DataInterface.py
@@ -48,6 +48,7 @@ class DataInterface:
         self.completeWaferList = []
         # cache test pin list and names for MPR
         self.pinInfoDictCache = {}
+        self.testNameNumDict = {}
         
         
     def loadDatabase(self):
@@ -73,6 +74,7 @@ class DataInterface:
         self.SBIN_dict = self.DatabaseFetcher.getBinInfo(isHBIN=False)
         # for UI display
         self.completeTestList = self.DatabaseFetcher.getTestItemsList()
+        self.testNameNumDict = self.DatabaseFetcher.getTestNameNumDict()
         self.completeWaferList = self.DatabaseFetcher.getWaferList()
         
         
@@ -304,10 +306,18 @@ class DataInterface:
             outData["Max"] = np.nan
             outData["Median"] = np.nan
                 
-        outData["Mean"], outData["SDev"], outData["Cpk"] = calc_cpk(outData["LLimit"], 
-                                                                    outData["HLimit"], 
+        outData["Mean"], outData["SDev"], outData["Cpk"] = calc_cpk(outData["LLimit"],
+                                                                    outData["HLimit"],
                                                                     outData["dataList"])
         return outData
+
+    def _find_test_by_basename(self, basename: str, fid: int):
+        '''Return (test_num, test_name) in given file if basename matches.'''
+        name_map = self.testNameNumDict.get(fid, {})
+        for name, num in name_map.items():
+            if strip_test_number(name) == basename:
+                return num, name
+        return None
     
     
     def getTestDataFromHeadSite(self, testTuple: tuple, selectHeads:list[int], selectSites:list[int], FileID: int) -> dict:
@@ -325,6 +335,13 @@ class DataInterface:
         # testID -> (test_num, test_name)
         testID = (testTuple[0], testTuple[-1])
         testInfo = self.DatabaseFetcher.getTestInfo(testID, FileID)
+        if len(testInfo) == 0:
+            basename = strip_test_number(testTuple[-1])
+            alt = self._find_test_by_basename(basename, FileID)
+            if alt:
+                testID = alt
+                testTuple = (alt[0], testTuple[1], alt[1])
+                testInfo = self.DatabaseFetcher.getTestInfo(testID, FileID)
         if len(testInfo) == 0:
             return {}
         # add (head, site) list to testInfo for MPR
@@ -354,7 +371,14 @@ class DataInterface:
         testID = (testTuple[0], testTuple[-1])
         testInfo = self.DatabaseFetcher.getTestInfo(testID, FileID)
         if len(testInfo) == 0:
-            return {}        
+            basename = strip_test_number(testTuple[-1])
+            alt = self._find_test_by_basename(basename, FileID)
+            if alt:
+                testID = alt
+                testTuple = (alt[0], testTuple[1], alt[1])
+                testInfo = self.DatabaseFetcher.getTestInfo(testID, FileID)
+        if len(testInfo) == 0:
+            return {}
         # add (head, site) list to testInfo for MPR
         # it will be used for indexing channel name dict
         # 

--- a/deps/DatabaseFetcher.py
+++ b/deps/DatabaseFetcher.py
@@ -367,6 +367,18 @@ class DatabaseFetcher:
             nested = TestFailCnt[(TEST_NUM, TEST_NAME)]
             nested[Fid] = FailCount
         return TestFailCnt
+
+
+    def getTestNameNumDict(self) -> dict:
+        '''return dict of Fid -> {TEST_NAME: TEST_NUM}'''
+        if self.cursor is None:
+            raise RuntimeError("No database is connected")
+
+        nameMap = {}
+        for Fid, TEST_NUM, TEST_NAME in self.cursor.execute(
+                "SELECT Fid, TEST_NUM, TEST_NAME FROM Test_Info"):
+            nameMap.setdefault(Fid, {})[TEST_NAME] = TEST_NUM
+        return nameMap
     
     
     def getDUTCountDict(self):

--- a/deps/SharedSrc.py
+++ b/deps/SharedSrc.py
@@ -637,6 +637,18 @@ def parseTestString(test_name_string: str, isWaferName: bool = False) -> tuple:
         return (test_num, pmr, test_name)
 
 
+def strip_test_number(test_name: str) -> str:
+    '''
+    Return test name without the trailing number if it is separated by
+    whitespace. Used for matching test items whose last word is the test
+    number.
+    '''
+    parts = test_name.strip().split()
+    if parts and parts[-1].isdigit():
+        return " ".join(parts[:-1])
+    return test_name
+
+
 def openFileInOS(filepath: str):
     # https://stackoverflow.com/a/435669
     filepath = os.path.normpath(filepath)
@@ -796,8 +808,8 @@ __all__ = ["SettingParams", "tab", "REC", "symbolName", "symbolChar", "symbolCha
            "parseTestString", "isHexColor", "getProperFontColor", "init_logger", "runInQThread", 
            "loadFonts", "getLoadedFontNames", "rSymbol", "getIcon", "get_png_size", 
            "calc_cpk", "deleteWidget", "isPass", "isValidSymbol", "pyqtGraphPlot2Bytes", 
-           "showCompleteMessage", "rHEX", "get_file_size", "validateSession", 
-           
-           "translate_const_dicts", "dut_flag_parser", "test_flag_parser", "return_state_parser", 
-           "wafer_direction_name",
+           "showCompleteMessage", "rHEX", "get_file_size", "validateSession",
+
+           "translate_const_dicts", "dut_flag_parser", "test_flag_parser", "return_state_parser",
+           "wafer_direction_name", "strip_test_number",
            ]


### PR DESCRIPTION
## Summary
- support matching test names that only differ by trailing numbers
- expose helper `strip_test_number`
- query database for per-file name/number mapping
- look up matching tests across merged files
- show test titles without numeric suffixes in charts
- fix missing import in `ChartWidgets`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from deps.SharedSrc import strip_test_number
assert strip_test_number('test_a dvdd 33000766') == 'test_a dvdd'
print('ok1')
PY`
- `maturin build -f -r` & `pip install target/wheels/*.whl`

------
https://chatgpt.com/codex/tasks/task_e_687f55c48d30832f8f340b666c558a67